### PR TITLE
bug fix with the ID string rendering

### DIFF
--- a/partials/builder/sections/hero.htm
+++ b/partials/builder/sections/hero.htm
@@ -1,7 +1,7 @@
 [global settings]
 handle = "Content\Settings"
 ==
-<header {{ section.html_anchor|length ? 'id="' ~  section.html_anchor  ~ '"' }}
+<header {{ section.html_anchor|length ? 'id=' ~  section.html_anchor  ~ '' }}
         class="hero
                {{ section.size == 'small' ? 'small-hero' }} 
                bg-dark 


### PR DESCRIPTION
the ID string rendered with double quote `id=""my_id""` instead of `id="my_id"`